### PR TITLE
Fix regexp issue when determining keyid used to encrypt the key file

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=initramfs-scencrypt
 pkgdesc="initramfs hook that adds PGP smartcard support for LUKS FDE"
-pkgver=1.3
+pkgver=1.4
 pkgrel=1
 arch=(any)
 depends=(gnupg pcsclite libusb-compat)

--- a/scencrypt-install
+++ b/scencrypt-install
@@ -42,7 +42,7 @@ build() {
         if [ "${f:0:1}" = "/" -a -f "$f" ]; then
             add_file "$f"
             # Determine the keyid used to encrypt this keyfile
-            keyid=$(gpg --list-packets --list-only $f 2>&1 | egrep -o 'ID [0-9A-F]{16}' | awk '{print $2;}')
+            keyid=$(gpg --list-packets --list-only $f 2>&1 | egrep -o '[0-9A-F]{16}' | awk '{print $1;}')
 
             # If we got a keyid, export that key. Recent versions of GPG will fail to
             # export secret key stubs, so if we don't get any output, export just the


### PR DESCRIPTION
Hi,

The current output of the command `gpg --list-packets --list-only disk.bin.gpg` differes from previous versions of GPG packaged in Arch.

Current output:
```
$ gpg --list-packets --list-only plop.gpg
# off=0 ctb=85 tag=1 hlen=3 plen=268
:pubkey enc packet: version 3, algo 1, keyid 02927E70ED932BAE
	data: [2047 bits]

# off=271 ctb=d2 tag=18 hlen=2 plen=120 new-ctb
:encrypted data packet:
	length: 120
	mdc_method: 2
```

The result is that during the installation of the hook, the keyid used to encrypt the key file isn't grabbed and the public keys not imported.

This pull request simplifies and corrects the regexp used to grab the keyid

Pierre.