### PR TITLE
Check key files given in /etc/crypttab if ending in .gpg

### DIFF
--- a/scencrypt-install
+++ b/scencrypt-install
@@ -33,7 +33,7 @@ build() {
     add_file "/usr/lib/udev/rules.d/95-dm-notify.rules"
     add_file "/usr/lib/initcpio/udev/11-dm-initramfs.rules" "/usr/lib/udev/rules.d/11-dm-initramfs.rules"
     
-    add_file "/etc/crypttab"
+    # add_file "/etc/crypttab" # file is added later line by line
 
     ln -s "pinentry-tty" "$BUILDROOT/usr/bin/pinentry"
 
@@ -42,22 +42,28 @@ build() {
     while read f; do
         # Path must begin with a slash and must be a regular file
         if [ "${f:0:1}" = "/" -a -f "$f" ]; then
-            # Determine the keyid used to encrypt this keyfile
-            keyid=$(gpg -q --list-packets --list-only $f 2>&1 | egrep -o '(ID|keyid) [0-9A-F]{16}' | awk '{print $2;}' | tail -1)
+            # file must end in .gpg
+            if [ "${f##*.}" = "gpg" ] ; then
+                # add file line to crypttab
+                grep $f /etc/crypttab >> "$BUILDROOT/etc/crypttab"
 
-            # If we got a keyid, export that key. Recent versions of GPG will fail to
-            # export secret key stubs, so if we don't get any output, export just the
-            # public key. Note that this means decryption will fail if you add only the
-            # public key to root's keyring.
-            if [ -n "$keyid" ]; then
-                add_file "$f"
-                keyfile=/tmp/$keyid.asc
-                gpg --homedir /root/.gnupg --export-options export-minimal --export-secret-keys -a 0x${keyid} 2>/dev/null > $keyfile
-                if ! egrep -q '.*' $keyfile; then
-                    gpg --homedir /root/.gnupg --export-options export-minimal --export -a 0x${keyid} > $keyfile
+                # Determine the keyid used to encrypt this keyfile
+                keyid=$(gpg -q --list-packets --list-only $f 2>&1 | egrep -o '(ID|keyid) [0-9A-F]{16}' | awk '{print $2;}' | tail -1)
+
+                # If we got a keyid, export that key. Recent versions of GPG will fail to
+                # export secret key stubs, so if we don't get any output, export just the
+                # public key. Note that this means decryption will fail if you add only the
+                # public key to root's keyring.
+                if [ -n "$keyid" ]; then
+                    add_file "$f"
+                    keyfile=/tmp/$keyid.asc
+                    gpg --homedir /root/.gnupg --export-options export-minimal --export-secret-keys -a 0x${keyid} 2>/dev/null > $keyfile
+                    if ! egrep -q '.*' $keyfile; then
+                        gpg --homedir /root/.gnupg --export-options export-minimal --export -a 0x${keyid} > $keyfile
+                    fi
+                    gpg --homedir "$BUILDROOT/etc/initcpio/gpg" --import $keyfile
+                    rm -f $keyfile
                 fi
-                gpg --homedir "$BUILDROOT/etc/initcpio/gpg" --import $keyfile
-                rm -f $keyfile
             fi
         fi
     done


### PR DESCRIPTION
This is a pull request regarding #13 

In the install file, it checks each line of the crypttab file if the key file is ending in .gpg and only if so adding it to the crypttab file in the initramfs.

I also incremented the version number with 0.0.1 to inform about this change