### PR TITLE
Fix: luksOpen fails: libgcc_s.so.1 must be installed for pthread_cancel to work

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -94,3 +94,37 @@ nUA1AQDMkiVNxuOEXCUp1R5umStJH1bgQXOoHKeAmbcnYgvXKgD/ZGZbFwMKGmeX
 -----END PGP SIGNATURE-----
 ```
 
+----
+
+Legal Name: Christoph Hoopmann
+
+GitHub username: https://github.com/choopm
+
+PGP key ID: 0x331552D979DFD7B351DD328D1BF7E603AB689BB7
+
+License release:
+
+```
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+I'm hereby licensing my contributions to github.com/fuhry/initramfs-scencrypt,
+present and future, under the MIT license (SPDX "MIT", https://spdx.org/licenses/MIT.html#licenseText)
+-----BEGIN PGP SIGNATURE-----
+
+iQIzBAEBCAAdFiEEMxVS2Xnf17NR3TKNG/fmA6tom7cFAl151lMACgkQG/fmA6to
+m7fxkhAAsrGb4PJXZo+dnKPdfbzKiikJMaDSrW8F3LmoLRCZEPESpKze36IDH5SB
+qcGVQYI6i2w6uZTHUAetOIDl5gddua4L5CBh+UOKFQUj/YJ0hJeYzrPgyXCh0y1G
+EMxuetk+RWuDB1aD8Eov/GL4eTO2Dpl+snPKYbTgiGmON+a43DYP+Aidn1SVGf4V
+cxOsqDK+PGmM2xF8NBWzVB69gkxj9SAsP3d9yNPjgs14RarOaZ6YZJL2A8zhkteO
+ru49h7phVYB4bdckARnZPZkE6sLHF+InHQW0k7cwJMwQ/5u7ixMHpHDD4I/h+Gko
+hiPmsh5iUHInXmvOxQpmxEuYzSwAPdIiLntZcXCeEa/hG2TMwDxd+jpbrc5pILoc
+V8bfKyUcr1aJdI7ofDLLjSWefMDBVWrkorayEgcMJnKc4qU+2uF9Rm6h/bT5mEqi
+1vXk5KEJngDIVeAaFsVqTkPExoTgO+0qFb4xfpHkWzexQ6yIcilir/C92SJiJIys
+thxqsh4XPOdeZlQ4fkwllK6aDKDciBtYhnwDgcYUaibnUp9Fnhep6BARY9ZO9PrM
+oPnQG+8+Io4TO9xqfM2HpG/Rqa5aJNICYpg6Qb7BRUwH2jO4EszASSsqPlbNBgPE
+x+vlOtVX1SUgHBNlOwOJbaoj2VyQRrsavA9WzgDtuWshghRenZg=
+=vP+F
+-----END PGP SIGNATURE-----
+```
+

--- a/scencrypt-install
+++ b/scencrypt-install
@@ -32,7 +32,10 @@ build() {
     add_file "/usr/lib/udev/rules.d/13-dm-disk.rules"
     add_file "/usr/lib/udev/rules.d/95-dm-notify.rules"
     add_file "/usr/lib/initcpio/udev/11-dm-initramfs.rules" "/usr/lib/udev/rules.d/11-dm-initramfs.rules"
-    
+
+    # cryptsetup calls pthread_create(), which dlopen()s libgcc_s.so.1
+    add_binary "/usr/lib/libgcc_s.so.1"
+
     # add_file "/etc/crypttab" # file is added later line by line
 
     ln -s "pinentry-tty" "$BUILDROOT/usr/bin/pinentry"
@@ -68,7 +71,7 @@ build() {
             fi
         fi
     done
-    
+
     add_runscript
 }
 


### PR DESCRIPTION
Copied from the arch default encrypt hook (/usr/lib/initcpio/install/encrypt).

Signed-off-by: Christoph Hoopmann <christophhoopmann@gmail.com>