### PR TITLE
Add: Support for cryptkey= cmdline argument to use plain key files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ As is the case with all LUKS systems, anyone who gets root on your box after it'
 
 PGP smart cards have varying options for PIN limits and reset or self-destruct functionality - choose one that fits your needs.
 
-This hook has only been tested with the Yubikey NEO.
+This hook has only been tested with the YubiKey NEO.
 
 ## Disclaimer
 
@@ -36,6 +36,8 @@ Use this hook at your own risk. It's highly recommended to have a backup key som
 The hook works by copying your encrypted key file to the initramfs, decrypting it in memory, passing it to LUKS to unseal the disk, and then using `shred` to overwrite it in memory.
 
 Behind the scenes, `gpg` starts `scdaemon`, which talks to `pcscd` and `pinentry-tty` to get your PIN and pass it to the card along with the payload for decryption. The private key itself is held securely on the smartcard - it cannot be released even with the PIN on hand. But the decryption is quick because the payload is small. Once the disk is mounted, the smartcard can safely be removed from the system - the result of the decryption is merely a "user key" that LUKS uses to decrypt the volume's master key. There is an excellent [white paper](http://clemens.endorphin.org/nmihde/nmihde-A4-ds.pdf) written by one of the original LUKS authors detailing LUKS's extensive anti-forensic hardening.
+
+The hook will prefer `cryptkey=` kernel cmdline argument if present. It uses the same options as the stock `encrypt` hook, refer to the `cryptsetup` package for details. This allows you to use `kexec` without having to re-insert your YubiKey. For this to work you can kexec-load a `initrd` which contains the plain key file. For security reasons that initrd shall only reside in RAM. Have a look at [kexec-example.sh](kexec-example.sh).
 
 # How to contribute
 

--- a/kexec-example.sh
+++ b/kexec-example.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# This script will copy the initramfs to /dev/shm, add the plain key file and use kexec to
+# load the new kernel+initrd+cmdline. Afterwards you can trigger kexec directly or via systemd.
+# You could install a pacman hook for automation, ex: /etc/pacman.d/hooks/100-kexec-load.hook
+# [Trigger]
+# Type = File
+# Operation = Install
+# Operation = Upgrade
+# Target = boot/vmlinuz-linux
+# Target = boot/initramfs-linux.img
+# [Action]
+# Description = Preparing kexec
+# When = PostTransaction
+# Exec = /home/choopm/bin/kexec-load.sh linux
+
+LINUX="${1:-linux}"
+INITRAMFS="/boot/initramfs-$LINUX.img"
+KERNEL="/boot/vmlinuz-$LINUX"
+KEYFILE="/home/choopm/.luks.key"
+
+umask 0077
+CRYPTROOT_TMPDIR="$(mktemp -d --tmpdir=/dev/shm)"
+INITRD="${CRYPTROOT_TMPDIR}/initrd.img"
+ROOTFS="$CRYPTROOT_TMPDIR/rootfs"
+FILENAME="keyfile.bin"
+CMDLINE=$(echo "$(cat /proc/cmdline | sed 's/cryptkey[^ ]*//') cryptkey=rootfs:/${FILENAME}")
+KVERSION=$(file $KERNEL | sed -r 's/.*version ([^ ]*).*/\1/')
+mkdir -p $ROOTFS
+
+cleanup() {
+    shred -fu "$ROOTFS/$FILENAME" || true
+    shred -fu "$INITRD" || true
+    rm -rf "${CRYPTROOT_TMPDIR}"
+}
+trap cleanup INT TERM EXIT
+
+echo "==> Patching and kexec-loading ${INITRD}"
+
+cd "${ROOTFS}"
+cat "${INITRAMFS}" | gzip -cd | cpio --quiet -i
+cp $KEYFILE $FILENAME
+find . | cpio --quiet -H newc -o | gzip >> "${INITRD}"
+
+/usr/bin/kexec -l "${KERNEL}" --initrd="${INITRD}" --command-line="${CMDLINE}"
+echo "==> Loaded kernel ${KVERSION}, use: systemctl kexec to reboot"
+

--- a/scencrypt-hook
+++ b/scencrypt-hook
@@ -61,6 +61,34 @@ run_hook() {
     modprobe -a -q dm-crypt >/dev/null 2>&1
     [ "${quiet}" = "y" ] && CSQUIET=">/dev/null"
 
+    # Get plain key file if specified, example: cryptkey=/dev/sda:2048:4096, cryptkey=rootfs:/keyfile.bin
+    ckeyfile=
+    if [ -n "$cryptkey" ]; then
+        IFS=: read ckdev ckarg1 ckarg2 <<EOF
+$cryptkey
+EOF
+
+        if [ "$ckdev" = "rootfs" ]; then
+            ckeyfile=$ckarg1
+        elif resolved=$(resolve_device "${ckdev}" ${rootdelay}); then
+            case ${ckarg1} in
+                *[!0-9]*)
+                    # Use a file on the device
+                    # ckarg1 is not numeric: ckarg1=filesystem, ckarg2=path
+                    mkdir /ckey
+                    mount -r -t "$ckarg1" "$resolved" /ckey
+                    dd if="/ckey/$ckarg2" of="$ckeyfile" >/dev/null 2>&1
+                    umount /ckey
+                    ;;
+                *)
+                    # Read raw data from the block device
+                    # ckarg1 is numeric: ckarg1=offset, ckarg2=length
+                    dd if="$resolved" of="$ckeyfile" bs=1 skip="$ckarg1" count="$ckarg2" >/dev/null 2>&1
+                    ;;
+            esac
+        fi
+    fi
+
     sed -re 's;#.*$;;g' -e '/^[ 	]*$/ d' -i /etc/crypttab
 
     IFS_BACKUP="$IFS"
@@ -77,6 +105,10 @@ EOF
         # handle case of no key file
         if [ "$key_file" = "-" -o "$key_file" = "none" ]; then
             key_file=
+        elif [ -r "${ckeyfile}" ]; then
+            # plain key file via cmdline cryptkey=
+            echo "Using plain key file specified in cryptkey="
+            key_file="${ckeyfile}"
         elif [ -c "${key_file}" ]; then
             # key file is a character device
             length=${keyarg1:-32}
@@ -141,14 +173,18 @@ EOF
             if cryptsetup isLuks "${device_path}"; then
                 # LUKS devices
 
-                # open device
+                # open device with key file
                 if [ -n "$key_file" ]; then
                     if ! eval cryptsetup luksOpen --key-file="${key_file}" \
                         $luksoptions "${resolved}" "${mapped_name}"; then
                         echo "WARNING: Failed to luksOpen crypto device" \
                             ${device_path}
+                        key_file=
                     fi
-                else
+                fi
+
+                # open device with passphrase
+                if [ ! -n "$key_file" ]; then
                     if ! eval cryptsetup luksOpen $luksoptions "${resolved}" \
                         "${mapped_name}"; then
                         echo "WARNING: Failed to luksOpen crypto device" \


### PR DESCRIPTION
The hook will now use a plain key file skipping decryption when `cryptkey=` cmdline argument is present. On failure it's falling back to passphrase. This allows to reboot using kexec without having to re-insert you YubiKey.