### PR TITLE
[RFC] Add support for systemd initcpio setups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pkg.tar.gz
 *.pkg.tar.xz
+*.pkg.tar.zst

--- a/95-smartcard.rules
+++ b/95-smartcard.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1050", ENV{ID_SMARTCARD_READER}=="?*", SYMLINK+="ykccid"
+

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,6 +14,7 @@ source=(scencrypt-hook
 		systemd-gpg-decrypt
 		systemd-cryptsetup-pgp-keyfile@.service
 		cryptsetup-gpg-dropin-generator
+		scencrypt-migrate
 		95-smartcard.rules
 		README.md)
 
@@ -45,6 +46,9 @@ package() {
 
 	mkdir -p "${pkgdir}/usr/share/doc/${pkgname}"
 	cp "${srcdir}/README.md" "${pkgdir}/usr/share/doc/${pkgname}/"
+	
+	mkdir -p "${pkgdir}/usr/bin"
+	install -oroot -m0755 "${srcdir}/scencrypt-migrate" "${pkgdir}/usr/bin/scencrypt-migrate"
 }
 
 sha256sums=('SKIP'
@@ -55,5 +59,6 @@ sha256sums=('SKIP'
          'SKIP'
          'SKIP'
          'SKIP'
+		 'SKIP'
          'SKIP'
          'SKIP')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=initramfs-scencrypt
 pkgdesc="initramfs hook that adds PGP smartcard support for LUKS FDE"
-pkgver=1.8
+pkgver=2.0
 pkgrel=1
 license=(MIT)
 arch=(any)
@@ -8,6 +8,13 @@ depends=(gnupg)
 install=${pkgname}.install
 source=(scencrypt-hook
 		scencrypt-install
+		systemd-initramfs-gpg-init.service
+		systemd-initramfs-gpg-init
+		systemd-gpg-decrypt@.service
+		systemd-gpg-decrypt
+		systemd-cryptsetup-pgp-keyfile@.service
+		cryptsetup-gpg-dropin-generator
+		95-smartcard.rules
 		README.md)
 
 build() {
@@ -16,15 +23,37 @@ build() {
 
 package() {
 	mkdir -p "${pkgdir}/usr/lib/initcpio/hooks"
-	mkdir -p "${pkgdir}/usr/lib/initcpio/install"
+	install -oroot -m0755 "${srcdir}/scencrypt-hook" "${pkgdir}/usr/lib/initcpio/hooks/scencrypt"
 
-	cp "${srcdir}/scencrypt-hook" "${pkgdir}/usr/lib/initcpio/hooks/scencrypt"
-	cp "${srcdir}/scencrypt-install" "${pkgdir}/usr/lib/initcpio/install/scencrypt"
-	
+	mkdir -p "${pkgdir}/usr/lib/initcpio/install"
+	install -oroot -m0755 "${srcdir}/scencrypt-install" "${pkgdir}/usr/lib/initcpio/install/scencrypt"
+
+	mkdir -p "${pkgdir}/usr/lib/systemd"
+	install -oroot -m0755 "${srcdir}/systemd-initramfs-gpg-init" "${pkgdir}/usr/lib/systemd/systemd-initramfs-gpg-init"
+	install -oroot -m0755 "${srcdir}/systemd-gpg-decrypt" "${pkgdir}/usr/lib/systemd/systemd-gpg-decrypt"
+
+	mkdir -p "${pkgdir}/usr/lib/systemd/system-generators"
+	install -oroot -m0755 "${srcdir}/cryptsetup-gpg-dropin-generator" "${pkgdir}/usr/lib/systemd/system-generators/cryptsetup-gpg-dropin-generator"
+
+	mkdir -p "${pkgdir}/usr/lib/systemd/system"
+	install -oroot -m0644 "${srcdir}/systemd-initramfs-gpg-init.service" "${pkgdir}/usr/lib/systemd/system/systemd-initramfs-gpg-init.service"
+	install -oroot -m0644 "${srcdir}/systemd-gpg-decrypt@.service" "${pkgdir}/usr/lib/systemd/system/systemd-gpg-decrypt@.service"
+	install -oroot -m0644 "${srcdir}/systemd-cryptsetup-pgp-keyfile@.service" "${pkgdir}/usr/lib/systemd/system/systemd-cryptsetup-pgp-keyfile@.service"
+
+	mkdir -p "${pkgdir}/usr/lib/initcpio/udev"
+	install -oroot -m0644 "${srcdir}/95-smartcard.rules" "${pkgdir}/usr/lib/initcpio/udev/95-smartcard.rules"
+
 	mkdir -p "${pkgdir}/usr/share/doc/${pkgname}"
 	cp "${srcdir}/README.md" "${pkgdir}/usr/share/doc/${pkgname}/"
 }
 
-md5sums=('SKIP'
+sha256sums=('SKIP'
+         'SKIP'
+         'SKIP'
+         'SKIP'
+         'SKIP'
+         'SKIP'
+         'SKIP'
+         'SKIP'
          'SKIP'
          'SKIP')

--- a/cryptsetup-gpg-dropin-generator
+++ b/cryptsetup-gpg-dropin-generator
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+set -x
+
+NORMAL_GENERATOR_DIR=${1:-/run/systemd/generator}
+EARLY_GENERATOR_DIR=$2
+LATE_GENERATOR_DIR=$3
+SYSTEM_GENERATOR_DIR="${NORMAL_GENERATOR_DIR}"
+UNIT_SOURCE_DIR=/usr/lib/systemd/system
+
+if [ -z "$PATH" ]; then
+	export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+fi
+
+condlink() {
+	if test -h "$2" ; then
+		rm -f "$2"
+	fi
+	if test -e "$2"; then
+		echo "cannot create symbolic link $2: file exists" >&2
+		return 1
+	fi
+	ln -s "$1" "$2"
+}
+
+generate_dropin() {
+	local mapped_name="$1"
+	local escaped_name="`systemd-escape "$mapped_name"`"
+	local cryptsetup_unit="systemd-cryptsetup@${escaped_name}.service"
+	local password_file="$2"
+	local password_escaped="`systemd-escape --path "${password_file}"`"
+	local password_unit="systemd-gpg-decrypt@${password_escaped}.service"
+	local keyfile_unit="systemd-cryptsetup-pgp-keyfile@${escaped_name}.service"
+
+	mkdir -p "$SYSTEM_GENERATOR_DIR/${password_unit}.d"
+	cat <<EOF > "$SYSTEM_GENERATOR_DIR/${password_unit}.d/10-path.conf"
+[Service]
+Environment=INPUT_FILE=${password_file}
+
+EOF
+
+	mkdir -p "$SYSTEM_GENERATOR_DIR/${keyfile_unit}.d"
+	cat <<EOF > "$SYSTEM_GENERATOR_DIR/${keyfile_unit}.d/10-parent.conf"
+[Unit]
+After=${password_unit}
+
+[Service]
+Environment=KEY_NAME=${password_escaped}
+EOF
+
+	mkdir -p "$SYSTEM_GENERATOR_DIR/${password_unit}.requires"
+	condlink "${UNIT_SOURCE_DIR}/systemd-initramfs-gpg-init.service" "$SYSTEM_GENERATOR_DIR/${password_unit}.requires/systemd-initramfs-gpg-init.service"
+
+	mkdir -p "$SYSTEM_GENERATOR_DIR/${keyfile_unit}.requires"
+	condlink "${UNIT_SOURCE_DIR}/systemd-gpg-decrypt@.service" "$SYSTEM_GENERATOR_DIR/${keyfile_unit}.requires/${password_unit}"
+
+	mkdir -p "$SYSTEM_GENERATOR_DIR/${cryptsetup_unit}.wants"
+	condlink "${UNIT_SOURCE_DIR}/systemd-cryptsetup-pgp-keyfile@.service" "$SYSTEM_GENERATOR_DIR/${cryptsetup_unit}.wants/${keyfile_unit}"
+	
+	mkdir -p "$SYSTEM_GENERATOR_DIR/cryptsetup-pre.target.wants"
+	condlink "${UNIT_SOURCE_DIR}/systemd-cryptsetup-pgp-keyfile@.service" "$SYSTEM_GENERATOR_DIR/cryptsetup-pre.target.wants/${keyfile_unit}"
+	condlink "${UNIT_SOURCE_DIR}/systemd-initramfs-gpg-init.service" "$SYSTEM_GENERATOR_DIR/cryptsetup-pre.target.wants/systemd-initramfs-gpg-init.service"
+}
+
+if test "$SYSTEMD_IN_INITRD" != "1"; then
+	exit 0
+fi
+
+while read line; do
+	line="${line%#*}"
+	IFS=$' \t' read mapped_name device keyfile options <<EOF
+$line
+EOF
+	for opt in ${options//,/ }; do
+		case "$opt" in
+			pgp-keyfile=*)
+				generate_dropin "$mapped_name" "${opt:12}"
+				;;
+			*)
+				: ;;
+		esac
+	done
+done < /etc/crypttab
+

--- a/initramfs-scencrypt.install
+++ b/initramfs-scencrypt.install
@@ -9,3 +9,13 @@ post_install() {
 	echo ""
 	echo " >> For more information, read /usr/share/doc/initramfs-scencrypt/README.md"
 }
+
+post_upgrade() {
+	echo " >> initramfs-scencrypt - READ ME!"
+	echo ""
+	echo -e " \e[0;1m>> \e[31;1mTHIS VERSION BREAKS BACKWARD COMPATIBILITY!"
+	echo -e " \e[0;1m>> Run the \e[36;1mscencrypt-migrate\e[0;1m command to automatically "
+	echo -e " \e[0;1m>> update your /etc/crypttab and key storage.\e[0m"
+	echo ""
+	echo " >> For more information, read /usr/share/doc/initramfs-scencrypt/README.md"
+}

--- a/initramfs-scencrypt.install
+++ b/initramfs-scencrypt.install
@@ -3,8 +3,9 @@ post_install() {
 	echo " >> Make sure to add your encrypted disks to /etc/crypttab. There is"
 	echo " >> no support for cryptdevice=... on the kernel command line."
 	echo ""
-	echo " >> Key file path must end in .gpg and the private key must be"
-	echo " >> accessible by root."
+	echo -e " \e[0;1m>> \e[31;1mTHIS VERSION BREAKS BACKWARD COMPATIBILITY!"
+	echo -e " \e[0;1m>> Run the \e[36;1mscencrypt-migrate\e[0;1m command to automatically "
+	echo -e " \e[0;1m>> update your /etc/crypttab and key storage.\e[0m"
 	echo ""
 	echo " >> For more information, read /usr/share/doc/initramfs-scencrypt/README.md"
 }

--- a/scencrypt-hook
+++ b/scencrypt-hook
@@ -58,6 +58,11 @@ retry() {
 }
 
 run_hook() {
+    INIT="`readlink -f /proc/1/exe`"
+    if test "${INIT##*/}" = "systemd" ; then
+        # we do not run under systemd
+        return 0
+    fi
     modprobe -a -q dm-crypt >/dev/null 2>&1
     [ "${quiet}" = "y" ] && CSQUIET=">/dev/null"
 
@@ -99,30 +104,38 @@ EOF
 $line
 EOF
 
+        # First, parse the key_spec field. The legacy behavior was to use the first
+        # argument in this column as the key path, and treat it as a PGP keyfile if
+        # the filename ends with ".gpg".
         IFS=: read key_file keyarg1 keyarg2 <<EOF
 $key_spec
 EOF
-        # handle case of no key file
-        if [ "$key_file" = "-" -o "$key_file" = "none" ]; then
-            key_file=
-        elif [ -r "${ckeyfile}" ]; then
-            # plain key file via cmdline cryptkey=
-            echo "Using plain key file specified in cryptkey="
-            key_file="${ckeyfile}"
-        elif [ -c "${key_file}" ]; then
-            # key file is a character device
-            length=${keyarg1:-32}
-            dd if=$key_file of=/keyfile.bin bs=1 count=$length >/dev/null 2>&1
-            key_file=/keyfile.bin
-        elif [ -b "${key_file}" ]; then
-            echo "ERROR: Key files on block devices are not supported yet."
-            key_file=
-        elif [ -r "${key_file}" -a "${key_file%.gpg}" != "${key_file}" ]; then
+
+        key_file_is_pgp=no
+        if test "${key_file%.gpg}" != "${key_file}"; then
+            key_file_is_pgp=yes
+        fi
+
+        # Now check the options column - the "new" way of specifying the key file is
+        # with the `pgp-keyfile=` option in the fourth column. This is for consistency
+        # with other FDE hooks.
+        IFS="$IFS_BACKUP"
+        for opt in ${options//,/ }; do
+            case "$opt" in
+                pgp-keyfile=*)
+                    key_file_is_pgp=yes
+                    key_file=${opt:12} ;;
+                *)
+                    : ;;
+            esac
+        done
+
+        if test -r "${key_file}" -a "$key_file_is_pgp" = "yes"; then
             # /.gnupg is where the scdaemon socket lives
             test -d /.gnupg || mkdir -p /.gnupg
             chmod -R go-rwx /.gnupg /etc/initcpio/gpg
 
-            # store the key at a known path. this allows the same key to be 
+            # store the key at a known path. this allows the same key to be
             # used for multiple disks and only have to decrypt once.
             key_dest_path=/etc/initcpio/gpg/key_${key_file//\//S}
 
@@ -132,7 +145,7 @@ EOF
             else
                 # we need to decrypt.
 
-                # test communication with card - this is also needed for 
+                # test communication with card - this is also needed for
                 # decryption to work at all
                 retry 60 "Waiting for the smartcard to be inserted
 (or press enter to falling back to passphrase)" card_status
@@ -148,6 +161,21 @@ EOF
                     key_file=
                 fi
             fi
+        elif [ "$key_file" = "-" -o "$key_file" = "none" ]; then
+            # handle case of no key file
+            key_file=
+        elif [ -r "${ckeyfile}" ]; then
+            # plain key file via cmdline cryptkey=
+            echo "Using plain key file specified in cryptkey="
+            key_file="${ckeyfile}"
+        elif [ -c "${key_file}" ]; then
+            # key file is a character device
+            length=${keyarg1:-32}
+            dd if=$key_file of=/keyfile.bin bs=1 count=$length >/dev/null 2>&1
+            key_file=/keyfile.bin
+        elif [ -b "${key_file}" ]; then
+            echo "ERROR: Key files on block devices are not supported yet."
+            key_file=
         elif [ -r "${key_file}" ]; then
             cp "${key_file}" /keyfile.bin
             key_file=/keyfile.bin
@@ -163,8 +191,10 @@ EOF
                 discard)
                     luksoptions="$luksoptions --allow-discards"
                     ;;
+                pgp-keyfile=*)
+                    : ;;
                 *)
-                    echo "Warning: ignoring unknown crypttab option: $option"
+                    echo "Warning: ignoring unknown crypttab option: $option" ;;
             esac
         done
 

--- a/scencrypt-hook
+++ b/scencrypt-hook
@@ -148,7 +148,7 @@ EOF
                 # test communication with card - this is also needed for
                 # decryption to work at all
                 retry 60 "Waiting for the smartcard to be inserted
-(or press enter to falling back to passphrase)" card_status
+(or press enter to use passphrase instead)" card_status
 
                 # now attempt to decrypt
                 if decrypt_file "${key_file}" "${key_dest_path}"; then

--- a/scencrypt-install
+++ b/scencrypt-install
@@ -24,14 +24,35 @@ build() {
     add_binary "cryptsetup"
     add_binary "dmsetup"
     add_binary "gpg"
+    add_binary "gpgconf"
     add_binary "gpg-agent"
     add_binary "pinentry-tty"
     add_binary "gpg-connect-agent"
     add_binary "/usr/lib/gnupg/scdaemon"
+    add_binary "/usr/bin/systemd-escape"
+    add_binary "/usr/bin/systemd-ask-password"
     add_file "/usr/lib/udev/rules.d/10-dm.rules"
     add_file "/usr/lib/udev/rules.d/13-dm-disk.rules"
     add_file "/usr/lib/udev/rules.d/95-dm-notify.rules"
     add_file "/usr/lib/initcpio/udev/11-dm-initramfs.rules" "/usr/lib/udev/rules.d/11-dm-initramfs.rules"
+    add_file "/usr/lib/initcpio/udev/95-smartcard.rules" "/usr/lib/udev/rules.d/95-smartcard.rules"
+
+    install -d -oroot -groot -m0755 "$BUILDROOT/usr/lib/systemd"
+    add_file "/usr/lib/systemd/systemd-initramfs-gpg-init"
+    add_file "/usr/lib/systemd/systemd-gpg-decrypt"
+
+    install -d -oroot -groot -m0755 "$BUILDROOT/usr/lib/systemd/system"
+    add_file "/usr/lib/systemd/system/systemd-initramfs-gpg-init.service"
+    add_file "/usr/lib/systemd/system/systemd-gpg-decrypt@.service"
+    add_file "/usr/lib/systemd/system/systemd-cryptsetup-pgp-keyfile@.service"
+
+    install -d -oroot -groot -m0755 "$BUILDROOT/usr/lib/systemd/system-generators"
+    add_file "/usr/lib/systemd/system-generators/cryptsetup-gpg-dropin-generator"
+
+    if [ -d /etc/initcpio/gpg/public-keys.d ]; then
+        install -d -oroot -groot -m0700 "$BUILDROOT/etc/initcpio/gpg"
+        add_full_dir "/etc/initcpio/gpg/public-keys.d"
+    fi
 
     # cryptsetup calls pthread_create(), which dlopen()s libgcc_s.so.1
     add_binary "/usr/lib/libgcc_s.so.1"
@@ -44,35 +65,46 @@ build() {
     mkdir -p $BUILDROOT/tmp
 
     # Iterate over entries in /etc/crypttab looking for regular keyfiles
-    sed -re 's;#.*$;;g' -e '/^[ \t]*$/ d' /etc/crypttab | awk '{print $3;}' | \
-    while read f; do
-        # Path must begin with a slash and must be a regular file
-        if [ "${f:0:1}" = "/" -a -f "$f" ]; then
-            # file must end in .gpg
-            extension="${f##*.}"
-            if [[ "${extension}" =~ ^(gpg|pgp|asc)$ ]] ; then
-                # add file line to crypttab
-                fgrep -w $f /etc/crypttab >> "$BUILDROOT/tmp/crypttab"
+    sed -re 's;#.*$;;g' -e '/^[ \t]*$/ d' /etc/crypttab > "$BUILDROOT/tmp/crypttab"
+    while read line; do
+        # First, try to determine the password file using the new pgp-keyfile= option
+        IFS=$' \t' read mapped_name device password_file opts <<< "$line"
+        f=
+        for opt in ${opts//,/ }; do
+            case "$opt" in
+                pgp-keyfile=*)
+                    f=${opt:12} ;;
+                *)
+                    : ;;
+            esac
+        done
 
-                # Determine the keyid used to encrypt this keyfile
-                keyid=$(gpg -q --list-packets --list-only $f 2>&1 | egrep -o '(ID|keyid) [0-9A-F]{16}' | awk '{print $2;}' | tail -1)
+        if [ -z "$f" -a "${password_file:0:1}" = "/" -a -r "${password_file}" ]; then
+            # if we're using the legacy third column, the file path must end in .gpg
+            if [[ "${password_file##*.}" =~ ^(gpg|pgp|asc) ]]; then
+                f="$password_file"
+            fi
+        fi
 
-                # If we got a keyid, export that key. Recent versions of GPG will fail to
-                # export secret key stubs, so if we don't get any output, export just the
-                # public key. Note that this means decryption will fail if you add only the
-                # public key to root's keyring.
-                if [ -n "$keyid" ]; then
-                    keyfile="$BUILDROOT/tmp/$keyid.asc"
-                    gpg --homedir /root/.gnupg --export-options export-minimal --export-secret-keys -a 0x${keyid} 2>/dev/null > $keyfile
-                    if ! egrep -q '.*' $keyfile; then
-                        gpg --homedir /root/.gnupg --export-options export-minimal --export -a 0x${keyid} > $keyfile
-                    fi
-                    gpg --homedir "$BUILDROOT/etc/initcpio/gpg" --import $keyfile
+        if [ -n "$f" ]; then
+            # Determine the keyid used to encrypt this keyfile
+            keyid=$(gpg -q --list-packets --list-only $f 2>&1 | grep -Eo '(ID|keyid) [0-9A-F]{16}' | awk '{print $2;}' | tail -1)
+
+            # If we got a keyid, export that key. Recent versions of GPG will fail to
+            # export secret key stubs, so if we don't get any output, export just the
+            # public key. Note that this means decryption will fail if you add only the
+            # public key to root's keyring.
+            if [ -n "$keyid" ]; then
+                keyfile="$BUILDROOT/tmp/$keyid.asc"
+                gpg --homedir /root/.gnupg --export-options export-minimal --export-secret-keys -a 0x${keyid} 2>/dev/null > $keyfile
+                if ! grep -Eq '.*' $keyfile; then
+                    gpg --homedir /root/.gnupg --export-options export-minimal --export -a 0x${keyid} > $keyfile
                 fi
+                gpg --homedir "$BUILDROOT/etc/initcpio/gpg" --import $keyfile
             fi
             add_file "$f"
         fi
-    done
+    done < "$BUILDROOT/tmp/crypttab"
 
     # Remove duplicate lines (first sort and then use uniq)
     sort "$BUILDROOT/tmp/crypttab" | uniq >  "$BUILDROOT/etc/crypttab"

--- a/scencrypt-install
+++ b/scencrypt-install
@@ -108,8 +108,8 @@ build() {
 
     # Remove duplicate lines (first sort and then use uniq)
     sort "$BUILDROOT/tmp/crypttab" | uniq >  "$BUILDROOT/etc/crypttab"
-    # Remove tmp dir
-    rm -rf "$BUILDROOT/tmp"
+    # Remove temporary crypttab
+    rm -f "$BUILDROOT/tmp/crypttab"
 
     add_runscript
 }

--- a/scencrypt-migrate
+++ b/scencrypt-migrate
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -eu
+
+declare -r KEYDIR="/etc/initcpio/gpg/public-keys.d"
+if [ -r "/etc/crypttab.initramfs" ]; then
+	declare -r CRYPTTAB="/etc/crypttab.initramfs"
+elif [ -f "/etc/crypttab" ]; then
+	declare -r CRYPTTAB="/etc/crypttab"
+else
+	echo "ERROR: Cannot find /etc/crypttab or /etc/crypttab.initramfs" >&2
+	exit 1
+fi
+
+echo -n > "$CRYPTTAB.new"
+crypttab_changed=no
+while read line; do
+	IFS=" 	" read cryptname dev keyfile opts <<< "$line"
+	if [ "${line:0:1}" = "#" ]; then
+		echo "$line" >> "$CRYPTTAB.new"
+		continue
+	fi
+
+	if [ -z "$cryptname" -o -z "$dev" ]; then
+		echo "$line" >> "$CRYPTTAB.new"
+		continue
+	fi
+
+	if [ "$keyfile" = "none" ]; then
+		echo "$line" >> "$CRYPTTAB.new"
+		continue
+	fi
+
+	keyid="$(gpg --list-packets --batch --pinentry-mode cancel "${keyfile}" 2>/dev/null | grep -Eo 'keyid [0-9A-F]{16}' || true)"
+	if [ -z "${keyid}" ]; then
+		echo "$line" >> "$CRYPTTAB.new"
+		continue
+	fi
+
+	if [ -n "$opts" ]; then
+		opts+=","
+	fi
+	opts+="pgp-keyfile=${keyfile}"
+	echo -e "${cryptname}\t${dev}\tnone\t${opts}" >> "$CRYPTTAB.new"
+	crypttab_changed=yes
+done < "$CRYPTTAB"
+
+if [ "$crypttab_changed" = "yes" ]; then
+	echo "Automaticaly rewrote your ${CRYPTTAB} file:"
+	diff -u "${CRYPTTAB}" "${CRYPTTAB}.new" || true
+
+	mv "${CRYPTTAB}" "${CRYPTTAB}.old"
+	mv "${CRYPTTAB}.new" "${CRYPTTAB}"
+
+	echo "The old contents are preserved in /etc/crypttab.old."
+fi
+
+keys_exported=no
+while read line; do
+	if [ "${line:0:1}" = "#" ]; then
+		continue
+	fi
+
+	IFS=" 	" read cryptname dev keyfile opts <<< "$line"
+
+	if [ -z "$cryptname" -o -z "$dev" ]; then
+		continue
+	fi
+
+	# echo "cryptname: $cryptname"
+	# echo "device:    $dev"
+	# echo "keyfile:   $keyfile"
+	# echo "opts:      $opts"
+
+	opts=(${opts//,/ })
+	for opt in "${opts[@]}"; do
+		case "$opt" in
+			pgp-keyfile=*)
+				keyfile="${opt:12}"
+				keyid="$(gpg --list-packets --batch --pinentry-mode cancel "${keyfile}" 2>/dev/null | grep -Eo 'keyid [0-9A-F]{16}' || true)"
+				keyid="0x${keyid:6}"
+
+				if [ ! -r "${KEYDIR}/${keyid}.asc" ]; then
+					echo "Exporting public key ${keyid} to ${KEYDIR}/${keyid}.asc"
+					gpg --export -a "${keyid}" > "${KEYDIR}/${keyid}.asc"
+					keys_exported=yes
+				fi
+				;;
+			*) ;;
+		esac
+	done
+
+	# echo "--"
+done < "${CRYPTTAB}"
+
+if [ "$crypttab_changed" = "yes" -o "$keys_exported" = "yes" ]; then
+	echo "Your system was modified. Rebuilding initramfs."
+	mkinitcpio -P
+fi

--- a/systemd-cryptsetup-pgp-keyfile@.service
+++ b/systemd-cryptsetup-pgp-keyfile@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Install keyfile for LUKS device %i
+Before=systemd-cryptsetup@%i.service
+DefaultDependencies=no
+Conflicts=shutdown.target initrd-switch-root.target
+Before=sysinit.target cryptsetup-pre.target cryptsetup.target shutdown.target initrd-switch-root.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=-/bin/mkdir -p /run/cryptsetup-keys.d
+ExecStartPre=/bin/chmod 0700 /run/cryptsetup-keys.d
+ExecStart=/bin/cp /run/systemd/cryptsetup/${KEY_NAME}.key /run/cryptsetup-keys.d/%I.key
+ExecStop=/bin/rm -f /run/cryptsetup-keys.d/%I.key
+
+[Install]
+WantedBy=cryptsetup-pre.target

--- a/systemd-gpg-decrypt
+++ b/systemd-gpg-decrypt
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+INPUT="$1"
+INSTANCE="$2"
+
+if [ -z "$INPUT" -o -z "$INSTANCE" ]; then
+	echo "Usage: $0 input_file instance_name" >&2
+	exit 1
+fi
+
+gpgout="`gpg --list-packets --batch --pinentry-mode cancel "$INPUT" 2>&1 | head -2`"
+if [ $? -gt 0 ]; then
+	echo "Input file $INPUT doesn't contain valid PGP encrypted data." >&2
+	exit 1
+fi
+
+line1="`echo "$gpgout" | head -1`"
+line2="`echo "$gpgout" | tail -1`"
+
+line1="${line1#gpg: encrypted with }"
+line2="${line2#*\"}"
+line2="${line2%\"}"
+
+password_or_pin="`/usr/bin/systemd-ask-password "Password or Smartcard PIN for $line1 ($line2)"`"
+if [ -z "$password_or_pin" ]; then
+	echo "ERROR: No password or PIN specified." >&2
+	exit 1
+fi
+
+umask 0077
+test -d "/run/systemd/cryptsetup" || mkdir -p "/run/systemd/cryptsetup"
+
+echo "$password_or_pin" | gpg --decrypt --quiet --passphrase-fd 0 -o "/run/systemd/cryptsetup/${INSTANCE}.key" --batch --yes --pinentry-mode loopback "$INPUT"
+

--- a/systemd-gpg-decrypt@.service
+++ b/systemd-gpg-decrypt@.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Decrypt keyfile %i with GnuPG
+After=systemd-initramfs-gpg-init.service dev-ykccid.device
+Wants=dev-ykccid.device
+Requires=systemd-initramfs-gpg-init.service
+
+DefaultDependencies=no
+Conflicts=shutdown.target initrd-switch-root.target
+Before=sysinit.target cryptsetup-pre.target cryptsetup.target shutdown.target initrd-switch-root.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Environment=GNUPGHOME=/run/initramfs/gnupg
+ExecStartPre=-/usr/bin/gpg --card-status
+ExecStart=/usr/lib/systemd/systemd-gpg-decrypt "$INPUT_FILE" "%i"
+ExecStop=/bin/rm -f /run/systemd/cryptsetup/%i.key
+
+[Install]
+WantedBy=cryptsetup-pre.target

--- a/systemd-initramfs-gpg-init
+++ b/systemd-initramfs-gpg-init
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+die() {
+	echo "$@" >&2
+	exit 1
+}
+
+if [ -z "$PATH" ]; then
+	PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+fi
+
+test -n "$GNUPGHOME" || die "GNUPGHOME is not set"
+test "${GNUPGHOME:0:5}" = "/run/" || die "GNUPGHOME is not under /run"
+
+test -d "$GNUPGHOME" || mkdir -p "$GNUPGHOME"
+chmod 0700 "$GNUPGHOME"
+
+gpg-connect-agent /bye
+for f in /etc/initcpio/gpg/public-keys.d/*.asc /etc/initcpio/gpg/public-keys.d/*.pub; do
+	if [ -r "$f" ]; then
+		gpg --import --batch --yes "$f"
+	fi
+done
+

--- a/systemd-initramfs-gpg-init.service
+++ b/systemd-initramfs-gpg-init.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Initialize GNUPGHOME in the initramfs
+DefaultDependencies=no
+Conflicts=shutdown.target initrd-switch-root.target
+Before=sysinit.target cryptsetup-pre.target cryptsetup.target shutdown.target initrd-switch-root.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Environment=GNUPGHOME=/run/initramfs/gnupg
+ExecStart=/usr/lib/systemd/systemd-initramfs-gpg-init
+ExecStop=/usr/bin/gpgconf --kill all
+ExecStop=/bin/rm -rf $GNUPGHOME
+
+[Install]
+WantedBy=cryptsetup-pre.target
+


### PR DESCRIPTION
Significant rewrite/expansion of the scencrypt hook to allow it to work with systemd-based initcpios.

Instead of replacing the `systemd-cryptsetup` flow, this method piggybacks on it by using a generator to add dependencies and overrides for systemd-cryptsetup disk targets, as follows:

* `systemd-initramfs-gpg-init.service` initializes the GPG homedir inside the initramfs by importing all of the public keys which were packed into the initramfs.
* `systemd-gpg-decrypt@.service` gets the passphrase or PIN from `systemd-ask-password` and passes it to gpg, which stores the keyfile at a known location (based on the key's filename).
* `systemd-cryptsetup-pgp-keyfile@.service` copies the key from the decrypted location to the `/run/cryptsetup-keys.d` directory where it is automatically picked up by `systemd-cryptsetup` and used to decrypt the disk.

Because it uses `systemd-ask-password`, this means you can even use plymouth!

Demo video running in a virtual machine with a real Yubikey passed through on USB: https://fuhry.com/b/initramfs-scencrypt-systemd-demo.webm

This does break backward compatibility with version 1.x, because there is no way to make `systemd-cryptsetup` work when the key-file column (column 3) of crypttab points to a file. It has to be set to `none` and the pgp keyfile must be passed in an option instead. A migration script (aptly named `scencrypt-migrate`) is included which mostly automates the process of modifying crypttab.